### PR TITLE
V2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
       }
     ],
     "require": {
-        "socialiteproviders/lifesciencelogin": "^5.0"
+        "socialiteproviders/lifesciencelogin": "^6.0"
     },
     "autoload": {
       "psr-4": {

--- a/src/Http/Controllers/LSLoginController.php
+++ b/src/Http/Controllers/LSLoginController.php
@@ -7,6 +7,7 @@ use Biigle\Modules\AuthLSLogin\LsloginId;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\InvalidStateException;
 
 class LSLoginController extends Controller
 {
@@ -28,7 +29,15 @@ class LSLoginController extends Controller
      */
     public function callback(Request $request)
     {
-        $user = Socialite::driver('lifesciencelogin')->user();
+        try {
+            $user = Socialite::driver('lifesciencelogin')->user();
+        } catch (InvalidStateException $e) {
+            $route = $request->user() ? 'settings-authentication' : 'login';
+
+            return redirect()
+                    ->route($route)
+                    ->withErrors(['lslogin-id' => 'There was an unexpected error. Please try again.']);
+        }
 
         $lslId = LsloginId::with('user')->find($user->id);
 

--- a/tests/Http/Controllers/LSLoginControllerTest.php
+++ b/tests/Http/Controllers/LSLoginControllerTest.php
@@ -15,7 +15,7 @@ class LSLoginControllerTest extends TestCase
     public function testRedirect()
     {
         $this->get('auth/lslogin/redirect')
-            ->assertRedirectContains('https://proxy.aai.lifescience-ri.eu');
+            ->assertRedirectContains('https://login.aai.lifescience-ri.eu');
     }
 
     public function testCallbackNewUser()


### PR DESCRIPTION
LSLogin v2 uses a new config URL now. Services can be self-managed via https://services.aai.lifescience-ri.eu/. Once you upgrade to the new provider version, you have to update the `LSLOGIN_CLIENT_ID` and `LSLOGIN_CLIENT_SECRET`, too.